### PR TITLE
updated example project with latest sdk version

### DIFF
--- a/src/CastleDemo/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/src/CastleDemo/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
@@ -122,6 +122,9 @@ namespace CastleDemo.Areas.Identity.Pages.Account
         {
             var user = _context.Users.SingleOrDefault(x => x.Email == Input.Email);
 
+            var context = Castle.Context.FromHttpRequest(Request);
+            context.Ip = "1.2.3.4";
+
             return new ActionRequest()
             {
                 Event = castleEvent,
@@ -131,7 +134,7 @@ namespace CastleDemo.Areas.Identity.Pages.Account
                     ["email"] = Input.Email
                     // We should also include "registered_at", but the template web app doesn't save that information
                 },
-                Context = Castle.Context.FromHttpRequest(Request)
+                Context = context
             };
         }
     }

--- a/src/CastleDemo/Areas/Identity/Pages/Filter/Filter.cshtml.cs
+++ b/src/CastleDemo/Areas/Identity/Pages/Filter/Filter.cshtml.cs
@@ -72,6 +72,9 @@ namespace CastleDemo.Areas.Identity.Pages.Filter
                 {"to", "$authenticator" }
             });
 
+            var context = Castle.Context.FromHttpRequest(Request);
+            context.Ip = "1.2.3.4";
+
             return new ActionRequest()
             {
                 Type = castleEvent,
@@ -81,7 +84,7 @@ namespace CastleDemo.Areas.Identity.Pages.Filter
                 Changeset = changeset,
                 Properties = properties,
                 RequestToken = "vru9P7qwelbdOiFyGPavoPdJNX9_7mTjsOtQ-2ewrl8qFLNILm_HcXtLrQwMmDNYExujcTMqu2IhWLNYZB3OA-K45FlZjLFUdBOzI0-b_jNRdt8wSjCGchs_mwtCcdczXGyTEn8_gmwFL4h8fHbdah8kkyQdK5p8am_DME5I1j5gdsdzHiyEchgpk3RgV-cRZzOTMEJ01nxsetA3RDaTH0Nt3DFOMIpqBS-daB0ph3IaLoN8eH7VPVl2nGkYKJ1vHT_2OEwwimoFL51tGyqHch0t31RKK4Q-TyyFbFwctNcri7s5Ty_WPR150MB9Xv0bZ1qTdGJxxzlHM5MVRWvWMANNmnxjW5MbWX7DNEJ8wHwdLIN8b3bBOUhrgBgaLpMqWECGAxs_wy90KuxsBz_3b28ugnEZKZ1uGzGCbBsxhG8ZKpr4Py-CcxsunG0SKINwCy-CZhsviWwbsLtcnj526q_Us48qwjAozB9YX9xS3FgPYkxeY9ezwSupCJ8ryHTojNcN44mqEupSq8zmSaXRGm1fd1wrH7OxxvJescZ35zR_d9fmkXTYGW77Pwy1F79cLR-zfhrg",
-                Context = Castle.Context.FromHttpRequest(Request)
+                Context = context
             };
         }
     }

--- a/src/CastleDemo/Areas/Identity/Pages/Log/Log.cshtml.cs
+++ b/src/CastleDemo/Areas/Identity/Pages/Log/Log.cshtml.cs
@@ -54,6 +54,9 @@ namespace CastleDemo.Areas.Identity.Pages.Log
             properties.Add("some prop", 1234);
             properties.Add("some prop12", product);
 
+            var context = Castle.Context.FromHttpRequest(Request);
+            context.Ip = "1.2.3.4";
+
             return new ActionRequest()
             {
                 Event = castleEvent,
@@ -65,7 +68,7 @@ namespace CastleDemo.Areas.Identity.Pages.Log
                 Properties = properties,
                 AuthenticationMethod = authMethod,
                 RequestToken = "vru9P7qwelbdOiFyGPavoPdJNX9_7mTjsOtQ-2ewrl8qFLNILm_HcXtLrQwMmDNYExujcTMqu2IhWLNYZB3OA-K45FlZjLFUdBOzI0-b_jNRdt8wSjCGchs_mwtCcdczXGyTEn8_gmwFL4h8fHbdah8kkyQdK5p8am_DME5I1j5gdsdzHiyEchgpk3RgV-cRZzOTMEJ01nxsetA3RDaTH0Nt3DFOMIpqBS-daB0ph3IaLoN8eH7VPVl2nGkYKJ1vHT_2OEwwimoFL51tGyqHch0t31RKK4Q-TyyFbFwctNcri7s5Ty_WPR150MB9Xv0bZ1qTdGJxxzlHM5MVRWvWMANNmnxjW5MbWX7DNEJ8wHwdLIN8b3bBOUhrgBgaLpMqWECGAxs_wy90KuxsBz_3b28ugnEZKZ1uGzGCbBsxhG8ZKpr4Py-CcxsunG0SKINwCy-CZhsviWwbsLtcnj526q_Us48qwjAozB9YX9xS3FgPYkxeY9ezwSupCJ8ryHTojNcN44mqEupSq8zmSaXRGm1fd1wrH7OxxvJescZ35zR_d9fmkXTYGW77Pwy1F79cLR-zfhrg",
-                Context = Castle.Context.FromHttpRequest(Request)
+                Context = context
             };
         }
     }

--- a/src/CastleDemo/Areas/Identity/Pages/Risk/Risk.cshtml
+++ b/src/CastleDemo/Areas/Identity/Pages/Risk/Risk.cshtml
@@ -13,7 +13,7 @@
         <span>A sample Risk request has been sent. Click below to resend</span>
         @using (Html.BeginForm(null, null, null, FormMethod.Get))
         {
-            <button type="submit" class="btn btn-primary" onclick="@Model.SendRisk()">Send Risk</button>
+            <button type="submit" class="btn btn-primary" onclick="@Model.SendRiskAsync()">Send Risk</button>
         }
     </div>
 </div>

--- a/src/CastleDemo/Areas/Identity/Pages/Risk/Risk.cshtml.cs
+++ b/src/CastleDemo/Areas/Identity/Pages/Risk/Risk.cshtml.cs
@@ -8,6 +8,8 @@ using Castle.Messages.Requests;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Threading;
 using System.Threading.Tasks;
+using System;
+using Castle.Infrastructure.Exceptions;
 
 namespace CastleDemo.Areas.Identity.Pages.Risk
 {
@@ -22,13 +24,22 @@ namespace CastleDemo.Areas.Identity.Pages.Risk
             _castleClient = castleClient;
         }
 
-        public async Task<ActionResult> SendRisk()
+        public async Task<ActionResult> SendRiskAsync()
         {
-
-            var res = await _castleClient.Risk(CreateCastleActionRequest("$profile_update"));
-
-            return Page();
-
+            try{
+                var res = await _castleClient.Risk(CreateCastleActionRequest("$profile_update"));
+                if(res.Failover)
+                {
+                    // Allow attempt. Data missing or invalid. See FailoverReason
+                }
+            } catch (Exception e)
+            {
+                if (e is CastleInvalidTokenException)
+                {
+                    // Deny attempt. Likely a bad actor bypassing fingerprinting
+                }
+            }
+            return null;
         }
 
         private ActionRequest CreateCastleActionRequest(string castleEvent)
@@ -40,7 +51,7 @@ namespace CastleDemo.Areas.Identity.Pages.Risk
             var user = new Dictionary<string, object>();
             user.Add("id", "12346-123142341-42314-4214123412");
             user.Add("email", "someuser@some-email.com");
-            user.Add("name", "some random  name");
+            user.Add("name", "name");
             user.Add("traits", traits);
 
 
@@ -51,6 +62,10 @@ namespace CastleDemo.Areas.Identity.Pages.Risk
             var properties = new Dictionary<string, object>();
             properties.Add("some prop", 1234);
 
+            // Override IP for testing purposes
+            var context = Castle.Context.FromHttpRequest(Request);
+            context.Ip = "1.2.3.4";
+
             return new ActionRequest()
             {
                 Event = castleEvent,
@@ -60,7 +75,7 @@ namespace CastleDemo.Areas.Identity.Pages.Risk
                 User = user,
                 Properties = properties,
                 RequestToken = "vru9P7qwelbdOiFyGPavoPdJNX9_7mTjsOtQ-2ewrl8qFLNILm_HcXtLrQwMmDNYExujcTMqu2IhWLNYZB3OA-K45FlZjLFUdBOzI0-b_jNRdt8wSjCGchs_mwtCcdczXGyTEn8_gmwFL4h8fHbdah8kkyQdK5p8am_DME5I1j5gdsdzHiyEchgpk3RgV-cRZzOTMEJ01nxsetA3RDaTH0Nt3DFOMIpqBS-daB0ph3IaLoN8eH7VPVl2nGkYKJ1vHT_2OEwwimoFL51tGyqHch0t31RKK4Q-TyyFbFwctNcri7s5Ty_WPR150MB9Xv0bZ1qTdGJxxzlHM5MVRWvWMANNmnxjW5MbWX7DNEJ8wHwdLIN8b3bBOUhrgBgaLpMqWECGAxs_wy90KuxsBz_3b28ugnEZKZ1uGzGCbBsxhG8ZKpr4Py-CcxsunG0SKINwCy-CZhsviWwbsLtcnj526q_Us48qwjAozB9YX9xS3FgPYkxeY9ezwSupCJ8ryHTojNcN44mqEupSq8zmSaXRGm1fd1wrH7OxxvJescZ35zR_d9fmkXTYGW77Pwy1F79cLR-zfhrg",
-                Context = Castle.Context.FromHttpRequest(Request)
+                Context = context
             };
         }
     }

--- a/src/CastleDemo/CastleDemo.csproj
+++ b/src/CastleDemo/CastleDemo.csproj
@@ -1,21 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<UserSecretsId>aspnet-CastleDemo-708B0CB0-0EAA-415A-87AA-60C6A98D774C</UserSecretsId>
-		<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Castle.Sdk" Version="2.1.1"/> 
-		<PackageReference Include="Microsoft.AspNetCore.App"/>
-		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102"/>
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.13"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.13"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13"/>
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.13"/>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.13"/>
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.13"/>
-		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.13"/>
+
+		<PackageReference Include="Castle.Sdk" Version="2.3.0"/>
+		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.19"/>
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0"/>
+		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0"/>
 	</ItemGroup>
 </Project>

--- a/src/CastleDemo/Startup.cs
+++ b/src/CastleDemo/Startup.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using CastleDemo.Data;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace CastleDemo
 {
@@ -21,12 +21,10 @@ namespace CastleDemo
 
         public IConfiguration Configuration { get; }
 
-        // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<CookiePolicyOptions>(options =>
             {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
                 options.CheckConsentNeeded = context => true;
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
@@ -38,25 +36,21 @@ namespace CastleDemo
                 .AddDefaultUI()
                 .AddEntityFrameworkStores<ApplicationDbContext>();
 
+            services.AddRazorPages();
 
-            services.AddMvc(option => option.EnableEndpointRouting = false).SetCompatibilityVersion(CompatibilityVersion.Latest);
-
-            // Castle IoC setup
             services.AddSingleton(new CastleClient(new CastleConfiguration(Configuration["Castle:ApiSecret"])));
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-                app.UseDatabaseErrorPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {
                 app.UseExceptionHandler("/Error");
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
 
@@ -64,9 +58,15 @@ namespace CastleDemo
             app.UseStaticFiles();
             app.UseCookiePolicy();
 
-            app.UseAuthentication();
+            app.UseRouting();
 
-            app.UseMvc();
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapRazorPages();
+            });
         }
     }
 }


### PR DESCRIPTION
- Upgrade Castle SDK from v2.1.1 to v2.3.0 and migrate the example project from .NET 6 / ASP.NET Core 5.x dependencies to .NET 9 / ASP.NET Core 9.0
- Update Startup.cs to use the modern ASP.NET Core hosting model: replace IHostingEnvironment with IWebHostEnvironment, swap UseMvc() for endpoint routing (MapRazorPages), replace UseDatabaseErrorPage() with UseMigrationsEndPoint(), and register Razor Pages explicitly
- Add error handling to the SendRiskAsync method (renamed from SendRisk) with CastleInvalidTokenException detection for bad-actor scenarios and failover response checking
- Override the request context IP to a test value (1.2.3.4) across Login, Filter, Log, and Risk pages for local development/testing